### PR TITLE
Update docker-compose-tls-False.yml

### DIFF
--- a/playbooks/docker/traefik/docker-compose-tls-False.yml
+++ b/playbooks/docker/traefik/docker-compose-tls-False.yml
@@ -22,6 +22,9 @@ services:
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
       - "--entryPoints.ping.address=:8082"
+      # allow upstream nginx to set the X-Forward headers
+      - "--entryPoints.web.proxyProtocol.insecure"
+      - "--entryPoints.web.forwardedHeaders.insecure"
 
       ## API Settings
       - "--api.dashboard=true"


### PR DESCRIPTION
allow X forward for header to be set/trusted by upfront nginx/apache