### PR TITLE
Enable pg_stat_statement by default for dhis2

### DIFF
--- a/roles/postgres/tasks/configure.yml
+++ b/roles/postgres/tasks/configure.yml
@@ -30,6 +30,7 @@
     - {name: 'random_page_cost', value: '{{postgres_random_page_cost | default(1.1)}}'}
     - {name: 'max_locks_per_transaction', value: '{{postgres_max_locks_per_transaction | default(96)}}'}
     - {name: 'jit', value: '{{postgres_jit | default("off")}}'}
+    - {name: 'shared_preload_libraries', value: '{{postgres_shared_preload_libraries | default("pg_stat_statements")}}'}
   become_user: postgres
   notify: postgresql__restart_service
 

--- a/roles/postgres/tasks/database.yml
+++ b/roles/postgres/tasks/database.yml
@@ -32,6 +32,12 @@
     db: "{{ DHIS2_DATABASE_NAME }}"
   become_user: postgres
   
+- name: "Create pg_stat_statements extention"
+  postgresql_ext:
+    name: pg_stat_statements
+    db: "{{ DHIS2_DATABASE_NAME }}"
+  become_user: postgres
+  
 - name: "ALTER dhis_db_name"
   command: psql -d {{ DHIS2_DATABASE_NAME }} -c "ALTER DATABASE {{ DHIS2_DATABASE_NAME }} SET SEARCH_PATH=PUBLIC,POSTGIS;"
   become_user: postgres


### PR DESCRIPTION
Before
```
dhis2=# select query from pg_stat_statements;
ERROR:  relation "pg_stat_statements" does not exist
LINE 1: select query from pg_stat_statements;
    

```
Already tested it
```
dhis2=# SELECT count(*) FROM pg_stat_statements;

 count 
-------
    46
(1 row)

```